### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index, :create]
+  before_action :move_to_index, except: [:index, :create, :show]
   def index
     @items = Item.all
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,6 +25,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/javascript/item_price.js
+++ b/app/javascript/item_price.js
@@ -1,11 +1,11 @@
 window.addEventListener('turbo:load', () => {
     const priceInput = document.getElementById('item-price')
     priceInput.addEventListener("input", () => {
-        const inputValue = priceInput.value;
-        const addTaxDom = document.getElementById('add-tax-price');
-        const tax_ratio = 0.1;
-        const tax = Math.floor(inputValue * tax_ratio);
-        if (typeof tax === 'number') {
+        const inputValue = parseFloat(priceInput.value);
+        if (!Number.isNaN(inputValue)) {
+            const addTaxDom = document.getElementById('add-tax-price');
+            const tax_ratio = 0.1;
+            const tax = Math.floor(inputValue * tax_ratio);
             addTaxDom.innerHTML = `${tax}`;
 
             const taxDom = document.getElementById('profit');

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,5 +1,5 @@
 <li class='list'>
-  <%= link_to "#" do %>
+  <%= link_to item_path(item.id) do %>
     <div class='item-img-content'>
       <%= image_tag item.image, class: "item-img" %>
       <%# <%if item.order.any?%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        item.price
+        <%=@item.price%>円
       </span>
       <span class="item-postage">
         <%= @item.which_delivery_payment.name %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,5 +1,4 @@
 <%= render "shared/header" %>
-
 <%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
@@ -7,66 +6,59 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag item.image ,class:"item-box-img" %>
+      <%# if item.order.any? %>
+      <%# <div class="sold-out"> %>
+      <%# <span>Sold Out!!</span>
+      </div> %>
+      <%# end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        item.price
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= item.which_delivery_payment.name %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <%if user_signed_in?%>
+      <%#if item.order.any? %>
+      <%if item.user.id==current_user.id%>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%end%>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%#end%>
+    <%end%>
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
     <table class="detail-table">
-      <tbody>
-        <tr>
-          <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
-        </tr>
-      </tbody>
+      <tr>
+        <th class="detail-item">出品者</th>
+        <td class="detail-value"><%= item.user.nick_name %></td>
+      </tr>
+      <tr>
+        <th class="detail-item">カテゴリー</th>
+        <td class="detail-value"><%= item.category.name %></td>
+      </tr>
+      <tr>
+        <th class="detail-item">商品の状態</th>
+        <td class="detail-value"><%= item.condition.name %></td>
+      </tr>
+      <tr>
+        <th class="detail-item">配送料の負担</th>
+        <td class="detail-value"><%= item.which_delivery_payment.name %></td>
+      </tr>
+      <tr>
+        <th class="detail-item">発送元の地域</th>
+        <td class="detail-value"><%= item.prefecture.name %></td>
+      </tr>
+      <tr>
+        <th class="detail-item">発送日の目安</th>
+        <td class="detail-value"><%= item.time_for_delivery.name%></td>
+      </tr>
     </table>
     <div class="option">
       <div class="favorite-btn">
@@ -80,7 +72,6 @@
     </div>
   </div>
   <%# /商品の概要 %>
-
   <div class="comment-box">
     <form>
       <textarea class="comment-text"></textarea>
@@ -92,20 +83,17 @@
       <button type="submit" class="comment-btn">
         <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
         <span>コメントする<span>
-      </button>
-    </form>
-  </div>
-  <div class="links">
-    <a href="#" class="change-item-btn">
-      ＜ 前の商品
-    </a>
-    <a href="#" class="change-item-btn">
-      後ろの商品 ＞
-    </a>
-  </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-</div>
-
-<%= render "shared/footer" %>
+          </button>
+        </form>
+      </div>
+      <div class="links">
+        <a href="#" class="change-item-btn">
+          ＜ 前の商品
+        </a>
+        <a href="#" class="change-item-btn">
+          後ろの商品 ＞
+        </a>
+      </div>
+      <a href="#" class="another-item"><%= item.category.name %>をもっと見る</a>
+    </div>
+    <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -6,7 +6,7 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag item.image ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# if item.order.any? %>
       <%# <div class="sold-out"> %>
       <%# <span>Sold Out!!</span>
@@ -18,12 +18,12 @@
         item.price
       </span>
       <span class="item-postage">
-        <%= item.which_delivery_payment.name %>
+        <%= @item.which_delivery_payment.name %>
       </span>
     </div>
     <%if user_signed_in?%>
       <%#if item.order.any? %>
-      <%if item.user.id==current_user.id%>
+      <%if @item.user.id==current_user.id%>
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
@@ -37,27 +37,27 @@
     <table class="detail-table">
       <tr>
         <th class="detail-item">出品者</th>
-        <td class="detail-value"><%= item.user.nick_name %></td>
+        <td class="detail-value"><%= @item.user.nick_name %></td>
       </tr>
       <tr>
         <th class="detail-item">カテゴリー</th>
-        <td class="detail-value"><%= item.category.name %></td>
+        <td class="detail-value"><%= @item.category.name %></td>
       </tr>
       <tr>
         <th class="detail-item">商品の状態</th>
-        <td class="detail-value"><%= item.condition.name %></td>
+        <td class="detail-value"><%= @item.condition.name %></td>
       </tr>
       <tr>
         <th class="detail-item">配送料の負担</th>
-        <td class="detail-value"><%= item.which_delivery_payment.name %></td>
+        <td class="detail-value"><%= @item.which_delivery_payment.name %></td>
       </tr>
       <tr>
         <th class="detail-item">発送元の地域</th>
-        <td class="detail-value"><%= item.prefecture.name %></td>
+        <td class="detail-value"><%= @item.prefecture.name %></td>
       </tr>
       <tr>
         <th class="detail-item">発送日の目安</th>
-        <td class="detail-value"><%= item.time_for_delivery.name%></td>
+        <td class="detail-value"><%= @item.time_for_delivery.name%></td>
       </tr>
     </table>
     <div class="option">
@@ -94,6 +94,6 @@
           後ろの商品 ＞
         </a>
       </div>
-      <a href="#" class="another-item"><%= item.category.name %>をもっと見る</a>
+      <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
     </div>
     <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -3,7 +3,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
@@ -32,7 +32,7 @@
       <%#end%>
     <%end%>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items,only: [:index,:new,:create]
+  resources :items,only: [:index,:new,:create,:show]
 end


### PR DESCRIPTION
# What
商品詳細画面の実装
# Why
- 買い手が商品の詳細情報の把握を行える
- 売り手が商品データの編集へのリンクを得られる。
# 商品の完売の有無に関して
Orderモデルを実装していないため、コメントアウトしています。

# 動画一覧
### ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
[![Image from Gyazo](https://i.gyazo.com/ccd7db01486a7f7d1b2608900bde4f15.gif)](https://gyazo.com/ccd7db01486a7f7d1b2608900bde4f15)

### ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
[![Image from Gyazo](https://i.gyazo.com/dc168d84e8bf3b82b58f868bad35ab98.gif)](https://gyazo.com/dc168d84e8bf3b82b58f868bad35ab98)

### ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
まだ、Orderモデルを実装していないため、なしです。
### ログアウト状態で、商品詳細ページへ遷移した動画
[![Image from Gyazo](https://i.gyazo.com/3cd048664a17fd7849f106c99e4dca16.gif)](https://gyazo.com/3cd048664a17fd7849f106c99e4dca16)

