### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :create, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :retrieve_all_active_hash, only: [:new, :edit, :create, :update]
+  before_action :your_item?, only: [:edit, :destroy]
   def index
     @items = Item.all
   end
@@ -20,18 +21,17 @@ class ItemsController < ApplicationController
     end
   end
 
-  def edit
-    return if @item.user.id == current_user.id
-
-    redirect_to root_path
-  end
-
   def update
     if @item.update(item_params)
       redirect_to item_path(@item.id)
     else
       render action: :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private
@@ -45,6 +45,12 @@ class ItemsController < ApplicationController
     return if user_signed_in?
 
     redirect_to new_user_session_path
+  end
+
+  def your_item?
+    return if @item.user.id == current_user.id
+
+    redirect_to root_path
   end
 
   def set_item

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
       <%if @item.user.id==current_user.id%>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
       <%end%>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <%#end%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items,only: [:index,:new,:create,:show,:edit,:update]
+  resources :items
 end


### PR DESCRIPTION
# What
商品削除ボタンを実装
# Why
出品者が、出品した商品を後から取り下げられるようにするため。

# 表示すべき動画
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
[![Image from Gyazo](https://i.gyazo.com/7fe9b476db02928f8262cd8bb726918f.gif)](https://gyazo.com/7fe9b476db02928f8262cd8bb726918f)