### PR TITLE
フォームオブジェクト名前変更

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -8,14 +8,14 @@ class OrdersController < ApplicationController
   before_action :sold_out!
   def index
     gon.public_key = ENV['PAYJP_PUBLIC_KEY']
-    @order_shipping_address_form = OrderShippingAddressForm.new
+    @order_form = OrderForm.new
   end
 
   def create
-    @order_shipping_address_form = OrderShippingAddressForm.new(order_params)
-    if @order_shipping_address_form.valid?
+    @order_form = OrderForm.new(order_params)
+    if @order_form.valid?
       pay_item
-      @order_shipping_address_form.save
+      @order_form.save
       redirect_to root_path
     else
       gon.public_key = ENV['PAYJP_PUBLIC_KEY']
@@ -34,7 +34,7 @@ class OrdersController < ApplicationController
   end
 
   def order_params
-    params.require(:order_shipping_address_form).permit(:postal_code, :prefecture_id, :city, :house_num, :building_name, :phone_number).merge(
+    params.require(:order_form).permit(:postal_code, :prefecture_id, :city, :house_num, :building_name, :phone_number).merge(
       item_id: @item.id, user_id: current_user.id, token: params[:token]
     )
   end

--- a/app/forms/order_form.rb
+++ b/app/forms/order_form.rb
@@ -1,4 +1,4 @@
-class OrderShippingAddressForm
+class OrderForm
   include ActiveModel::Model
   attr_accessor :postal_code, :prefecture_id, :city, :house_num, :building_name, :phone_number, :item_id, :user_id, :token
 

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -29,7 +29,7 @@
       </p>
     </div>
     <%# /支払額の表示 %>
-    <%= form_with model: @order_shipping_address_form,url:item_orders_path(@item.id),  id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @order_form,url:item_orders_path(@item.id),  id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
       <%#エラー情報の出力%>
       <%if f.object.errors.any?&&!f.object.valid?%>
         <%=render 'shared/error_messages', model: f.object %>


### PR DESCRIPTION
# What
フォームオブジェクトの名前変更
# Why
- フォームオブジェクトの名前があまりに長いため
- orderがaddressモデルに対して親であることを明示するため